### PR TITLE
Typo fix in Lecode isostacy 

### DIFF
--- a/UWGeodynamics/LecodeIsostasy/LecodeIsostasy.py
+++ b/UWGeodynamics/LecodeIsostasy/LecodeIsostasy.py
@@ -127,12 +127,12 @@ class LecodeIsostasy(object):
             if self.vertical_walls_conditions:
                 if self.vertical_walls_conditions["left"]:
                     if self.vertical_walls_conditions["left"][-1] is not None:
-                        left = self.mesh.specialSets["MinI_vertexSet"]
+                        left = self.mesh.specialSets["MinI_VertexSet"]
                         if left:
                             base -= left
                 if self.vertical_walls_conditions["right"]:
                     if self.vertical_walls_conditions["right"][-1] is not None:
-                        right = self.mesh.specialSets["MaxI_vertexSet"]
+                        right = self.mesh.specialSets["MaxI_VertexSet"]
                         if right:
                             base -= right
 
@@ -168,22 +168,22 @@ class LecodeIsostasy(object):
             if self.vertical_walls_conditions:
                 if self.vertical_walls_conditions["left"]:
                     if self.vertical_walls_conditions["left"][-1] is not None:
-                        left = self.mesh.specialSets["MinI_vertexSet"]
+                        left = self.mesh.specialSets["MinI_VertexSet"]
                         if left:
                             base -= left
                 if self.vertical_walls_conditions["right"]:
                     if self.vertical_walls_conditions["right"][-1] is not None:
-                        right = self.mesh.specialSets["MaxI_vertexSet"]
+                        right = self.mesh.specialSets["MaxI_VertexSet"]
                         if right:
                             base -= right
                 if self.vertical_walls_conditions["front"]:
                     if self.vertical_walls_conditions["front"][-1] is not None:
-                        front = self.mesh.specialSets["MinJ_vertexSet"]
+                        front = self.mesh.specialSets["MinJ_VertexSet"]
                         if front:
                             base -= front
                 if self.vertical_walls_conditions["back"]:
                     if self.vertical_walls_conditions["back"][-1] is not None:
-                        back = self.mesh.specialSets["MaxJ_vertexSet"]
+                        back = self.mesh.specialSets["MaxJ_VertexSet"]
                         if back:
                             base -= back
             bot_ids = base.data[base.data < self.mesh.nodesLocal]


### PR DESCRIPTION
affected call to the submodule, when left or right boundaries had prescribed y velocities 